### PR TITLE
Added feature to remove muted user from stream

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -1750,7 +1750,7 @@ def fly():
             magenta("We have maximum connection problem with twitter'stream API right now :("))
         printNicely(magenta("Let's try again later."))
         save_history()
-        sys.exit()   
+        sys.exit()
     # Spawn stream thread
     th = threading.Thread(
         target=stream,


### PR DESCRIPTION
I have added logic to store a dictionary of muted users. The key is the username with no '@' symbol (example:bman5252) and value is name (example: Bryan Salas). I chose to use username as key since they must be unique. This change required me to write a function that will build the global dictionary. I also edited the mute, unmute and muting functions to work with this new design. I have tested it on my local app too. 2 other things:
1. I don't know if you want this to be a config option or not, so I did not add one at this point, right now it is just the default.
2. One potential problem I see coming about is if a user is open in the rainbowstream app AND on twitter in an internet browser and they mute someone from the browser. The rainbowstream app would not be able to recognize that. I have a solution though that would involve making the build_mute_dic function a thread that runs every 30 seconds so that the global dict stays up to date. Let me know if you are okay with this idea or if you come up with a better one. Thanks!
