### PR TITLE
don't drop user input after spaces when attempting eval

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -1520,7 +1520,7 @@ def reset():
         printNicely(magenta('Need tips ? Type "h" and hit Enter key!'))
     g['reset'] = False
     try:
-        printNicely(str(eval(g['cmd'])))
+        printNicely(str(eval('%s %s' % (g['cmd'], g['stuff']))))
     except Exception:
         pass
 


### PR DESCRIPTION
Currently when Rainbowstream attempts to eval user input, it ignores any input after a space. So:

`[@myname]: 3 + 5`
`3`

when the answer should be 8. This pull request would fix that issue.
