### PR TITLE
c_image.py: use cc instead of gcc

### DIFF
--- a/rainbowstream/c_image.py
+++ b/rainbowstream/c_image.py
@@ -15,7 +15,7 @@ def call_c():
     library = expanduser('~/.image.so')
     sauce = join(dirname(__file__), 'image.c')
     if not exists(library) or getmtime(sauce) > getmtime(library):
-        build = "gcc -fPIC -shared -o %s %s" % (library, sauce)
+        build = "cc -fPIC -shared -o %s %s" % (library, sauce)
         assert os.system(build + " >/dev/null 2>&1") == 0
     image_c = ctypes.cdll.LoadLibrary(library)
     image_c.init()


### PR DESCRIPTION
Compile using `cc` instead of `gcc` to support systems where the
default C compiler is not GCC.  For example, GCC does not ship in
FreeBSD 10, but Clang is installed as `cc` and works fine.  On
systems where GCC is the default C compiler, it is usually installed
as `cc` as well, so this change should not result in problems for
existing users.
