### PR TITLE
added support for "open" follow https:// links

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -463,6 +463,8 @@ def urlopen():
         tweet = t.statuses.show(id=tid)
         link_ary = [
             u for u in tweet['text'].split() if u.startswith('http://')]
+        link_ary.extend([
+            u for u in tweet['text'].split() if u.startswith('https://')])
         if not link_ary:
             printNicely(light_magenta('No url here @.@!'))
             return


### PR DESCRIPTION
Hi,

Was using rainbowstream for a while, noticed that it would error "no link found" for https links.

Fixed the quick-and-dirtiest way I know how -- just adding https links to the list.

It's possible that you'll eventually want to deal with more initial strings later, but I didn't want to go messing around in your codebase too much.  This works for me.

open only works for links that start with "http://"
extended to deal with "https://"
