### PR TITLE
Reversed sorting for tweets in list

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -903,7 +903,7 @@ def list_home(t):
         owner_screen_name=owner,
         count=c['LIST_MAX'],
         include_entities=False)
-    for tweet in res:
+    for tweet in reversed(res):
         draw(t=tweet)
     printNicely('')
 


### PR DESCRIPTION
'home' command returns tweets ordered from oldest to newest.
This patch do same thing for 'list home' command
