### PR TITLE
stream argument and switch list argument

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -1314,7 +1314,10 @@ def switch():
             th.start()
         # Stream base on list
         elif target == 'list':
-            owner, slug = get_slug()
+            try:
+                owner, slug = check_slug(g['stuff'].split()[1])
+            except:
+                owner, slug = get_slug()
             # Force python 2 not redraw readline buffer
             listname = '/'.join([owner, slug])
             # Set the listname variable


### PR DESCRIPTION
I've added a startup argument to start directly into another stream (for example: 'rainbowstream -s "public lol"'). The commands are the same as the 'switch" commands.
I've also added the ability to use "switch list @user/list" as one command.
