### PR TITLE
Display the error message properly.

### DIFF
--- a/rainbowstream/util.py
+++ b/rainbowstream/util.py
@@ -9,12 +9,20 @@ def detail_twitter_error(twitterException):
     """
     Display Twitter Errors nicely
     """
-    data = twitterException.response_data
+    error_response = twitterException.response_data
     try:
-        for m in data.get('errors', dict()):
-            printNicely(yellow(m.get('message')))
-    except: 
-        printNicely(yellow(data))
+        if isinstance(error_response, bytes):
+            error_response = json.loads(error_response.decode('utf-8'))
+        elif isinstance(error_response, (str, unicode)):
+            error_response = json.loads(error_response)
+
+        for error in error_response.get('errors', {}):
+            error_code, message = error.get('code', ''), error.get('message', '')
+            info = "Error %s: %s" % (error_code, message)
+            printNicely(yellow(info))
+    except:
+        info = "Error: %r " % twitterException.response_data
+        printNicely(yellow(info))
 
 
 def format_prefix(listname='', keyword=''):


### PR DESCRIPTION
This change will show the error message properly.

When the response is json or python3 byte string or python string which could be encoded to to json.

```
We have connection problem with twitter REST API right now :(
Error 215: Bad Authentication data.
```

When we don't know the type.

```
We have connection problem with twitter REST API right now :(
Error: {u'errors': [{u'message': u'Bad Authentication data.', u'code': 215}]} 
```
