### PR TITLE
Added quoted tweets to `conversation` command

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -593,11 +593,11 @@ def conversation():
     limit = c['CONVERSATION_MAX']
     thread_ref = []
     thread_ref.append(tweet)
-    prev_tid = tweet['in_reply_to_status_id']
+    prev_tid = tweet['in_reply_to_status_id'] or tweet.get('quoted_status_id')
     while prev_tid and limit:
         limit -= 1
         tweet = t.statuses.show(id=prev_tid)
-        prev_tid = tweet['in_reply_to_status_id']
+        prev_tid = tweet['in_reply_to_status_id'] or tweet.get('quoted_status_id')
         thread_ref.append(tweet)
 
     for tweet in reversed(thread_ref):


### PR DESCRIPTION
This PR updates the `conversation` command to include quoted tweets in the conversation history instead of replies only. Many users tend to use quotes as an alternative way to reply to/comment on a thread, so `conversation` seemed like the appropriate command to piggyback on. I noticed a few folks had requested this in orakaro/rainbowstream#227, and the change was fairly straightforward so I thought putting it in a PR might be useful to others.