### PR TITLE
Add 280 character support

### DIFF
--- a/rainbowstream/colorset/config
+++ b/rainbowstream/colorset/config
@@ -1,4 +1,6 @@
 {
+    // Turn to 'true' in order to disable extended tweets display (legacy mode)
+    "DISABLE_EXTENDED_TWEETS" : false,
     // After 120 minutes, the stream will automatically hangup
     "HEARTBEAT_TIMEOUT" : 120,
     // Image on term

--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -175,6 +175,23 @@ def fallback_humanize(date, fallback_format=None, use_fallback=False):
     return clock
 
 
+def get_full_text(t):
+    """Handle RTs and extended tweets to always display all the available text"""
+
+    if t.get('retweeted_status'):
+        rt_status = t['retweeted_status']
+        if rt_status.get('extended_tweet'):
+            elem = rt_status['extended_tweet']
+        else:
+            elem = rt_status
+        rt_text = elem.get('full_text', elem.get('text'))
+        t['full_text'] = 'RT @' + rt_status['user']['screen_name'] + ': ' + rt_text
+    elif t.get('extended_tweet'):
+        t['full_text'] = t['extended_tweet']['full_text']
+
+    return t.get('full_text', t.get('text'))
+
+
 def draw(t, keyword=None, humanize=True, noti=False, fil=[], ig=[]):
     """
     Draw the rainbow
@@ -184,7 +201,8 @@ def draw(t, keyword=None, humanize=True, noti=False, fil=[], ig=[]):
 
     # Retrieve tweet
     tid = t['id']
-    text = t.get('full_text', t.get('text'))
+
+    text = get_full_text(t)
     screen_name = t['user']['screen_name']
     name = t['user']['name']
     created_at = t['created_at']
@@ -201,8 +219,6 @@ def draw(t, keyword=None, humanize=True, noti=False, fil=[], ig=[]):
 
     # Pull extended retweet text
     try:
-        text = 'RT @' + t['retweeted_status']['user']['screen_name'] + ': ' +\
-            t['retweeted_status']['text']
         # Display as a notification
         target = t['retweeted_status']['user']['screen_name']
         if all([target == c['original_name'], not noti]):
@@ -1067,7 +1083,7 @@ def format_quote(tweet):
     """
     # Retrieve info
     screen_name = tweet['user']['screen_name']
-    text        = tweet['text']
+    text = get_full_text(t)
     tid         = str( tweet['id'] )
 
     # Validate quote format

--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -184,7 +184,7 @@ def draw(t, keyword=None, humanize=True, noti=False, fil=[], ig=[]):
 
     # Retrieve tweet
     tid = t['id']
-    text = t['text']
+    text = t.get('full_text', t.get('text'))
     screen_name = t['user']['screen_name']
     name = t['user']['name']
     created_at = t['created_at']

--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -1083,7 +1083,7 @@ def format_quote(tweet):
     """
     # Retrieve info
     screen_name = tweet['user']['screen_name']
-    text = get_full_text(t)
+    text = get_full_text(tweet)
     tid         = str( tweet['id'] )
 
     # Validate quote format

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -331,8 +331,7 @@ def home():
     if g['stuff'].isdigit():
         num = int(g['stuff'])
     kwargs = {'count': num}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     for tweet in reversed(t.statuses.home_timeline(**kwargs)):
         draw(t=tweet)
     printNicely('')
@@ -359,8 +358,7 @@ def mentions():
     if g['stuff'].isdigit():
         num = int(g['stuff'])
     kwargs = {'count': num}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-	   kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     for tweet in reversed(t.statuses.mentions_timeline(**kwargs)):
         draw(t=tweet)
     printNicely('')
@@ -405,8 +403,7 @@ def view():
         except:
             num = c['HOME_TWEET_NUM']
         kwargs = {'count': num, 'screen_name': user[1:]}
-        if not c.get('DISABLE_EXTENDED_TWEETS'):
-            kwargs['tweet_mode'] = 'extended'
+        kwargs = add_tweetmode_parameter(kwargs)
         for tweet in reversed(t.statuses.user_timeline(**kwargs)):
             draw(t=tweet)
         printNicely('')
@@ -424,8 +421,7 @@ def view_my_tweets():
     except:
         num = c['HOME_TWEET_NUM']
     kwargs = {'count': num, 'screen_name': g['original_name']}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     for tweet in reversed(
             t.statuses.user_timeline(**kwargs)):
         draw(t=tweet)
@@ -452,8 +448,7 @@ def search():
         'type': type,
         'count': count,
     }
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     # Perform search
     rel = t.search.tweets(**kwargs)['statuses']
     # Return results
@@ -550,8 +545,7 @@ def quote():
         return
     tid = c['tweet_dict'][id]
     kwargs = {'id': tid}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     tweet = t.statuses.show(**kwargs)
     # Get formater
     formater = format_quote(tweet)
@@ -587,8 +581,7 @@ def allretweet():
         num = c['RETWEETS_SHOW_NUM']
     # Get result and display
     kwargs = {'id': tid, 'count': num}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     rt_ary = t.statuses.retweets(**kwargs)
     if not rt_ary:
         printNicely(magenta('This tweet has no retweet.'))
@@ -610,8 +603,7 @@ def conversation():
         return
     tid = c['tweet_dict'][id]
     kwargs = {'id': tid}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     tweet = t.statuses.show(**kwargs)
     limit = c['CONVERSATION_MAX']
     thread_ref = []
@@ -688,8 +680,7 @@ def favorite():
     t.favorites.create(_id=tid, include_entities=False)
     printNicely(green('Favorited.'))
     kwargs = {'id': tid}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     draw(t.statuses.show(**kwargs))
     printNicely('')
 
@@ -708,8 +699,7 @@ def unfavorite():
     t.favorites.destroy(_id=tid)
     printNicely(green('Okay it\'s unfavorited.'))
     kwargs = {'id': tid}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     draw(t.statuses.show(**kwargs))
     printNicely('')
 
@@ -726,8 +716,7 @@ def share():
         printNicely(red('Tweet id is not valid.'))
         return
     kwargs = {'id': tid}
-    if not c.get('DISABLE_EXTENDED_TWEETS'):
-        kwargs['tweet_mode'] = 'extended'
+    kwargs = add_tweetmode_parameter(kwargs)
     tweet = t.statuses.show(**kwargs)
     url = 'https://twitter.com/' + \
         tweet['user']['screen_name'] + '/status/' + str(tid)

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -440,7 +440,8 @@ def search():
     rel = t.search.tweets(
         q=query,
         type=type,
-        count=count
+        count=count,
+        tweet_mode='extended'
     )['statuses']
     # Return results
     if rel:

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -330,7 +330,10 @@ def home():
     num = c['HOME_TWEET_NUM']
     if g['stuff'].isdigit():
         num = int(g['stuff'])
-    for tweet in reversed(t.statuses.home_timeline(count=num, tweet_mode='extended')):
+    kwargs = {'count': num}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    for tweet in reversed(t.statuses.home_timeline(**kwargs)):
         draw(t=tweet)
     printNicely('')
 
@@ -355,7 +358,10 @@ def mentions():
     num = c['HOME_TWEET_NUM']
     if g['stuff'].isdigit():
         num = int(g['stuff'])
-    for tweet in reversed(t.statuses.mentions_timeline(count=num, tweet_mode='extended')):
+    kwargs = {'count': num}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+	   kwargs['tweet_mode'] = 'extended'
+    for tweet in reversed(t.statuses.mentions_timeline(**kwargs)):
         draw(t=tweet)
     printNicely('')
 
@@ -398,8 +404,10 @@ def view():
             num = int(g['stuff'].split()[1])
         except:
             num = c['HOME_TWEET_NUM']
-        for tweet in reversed(
-                t.statuses.user_timeline(count=num, screen_name=user[1:], tweet_mode='extended')):
+        kwargs = {'count': num, 'screen_name': user[1:]}
+        if not c.get('DISABLE_EXTENDED_TWEETS'):
+            kwargs['tweet_mode'] = 'extended'
+        for tweet in reversed(t.statuses.user_timeline(**kwargs)):
             draw(t=tweet)
         printNicely('')
     else:
@@ -415,8 +423,11 @@ def view_my_tweets():
         num = int(g['stuff'])
     except:
         num = c['HOME_TWEET_NUM']
+    kwargs = {'count': num, 'screen_name': g['original_name']}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
     for tweet in reversed(
-            t.statuses.user_timeline(count=num, screen_name=g['original_name'], tweet_mode='extended')):
+            t.statuses.user_timeline(**kwargs)):
         draw(t=tweet)
     printNicely('')
 
@@ -436,13 +447,15 @@ def search():
         type = 'mixed'
     max_record = c['SEARCH_MAX_RECORD']
     count = min(max_record, 100)
+    kwargs = {
+        'q': query,
+        'type': type,
+        'count': count,
+    }
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
     # Perform search
-    rel = t.search.tweets(
-        q=query,
-        type=type,
-        count=count,
-        tweet_mode='extended'
-    )['statuses']
+    rel = t.search.tweets(**kwargs)['statuses']
     # Return results
     if rel:
         printNicely('Newest tweets:')
@@ -536,7 +549,10 @@ def quote():
         printNicely(red('Sorry I can\'t understand.'))
         return
     tid = c['tweet_dict'][id]
-    tweet = t.statuses.show(id=tid, tweet_mode='extended')
+    kwargs = {'id': tid}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    tweet = t.statuses.show(**kwargs)
     # Get formater
     formater = format_quote(tweet)
     if not formater:
@@ -570,7 +586,10 @@ def allretweet():
     except:
         num = c['RETWEETS_SHOW_NUM']
     # Get result and display
-    rt_ary = t.statuses.retweets(id=tid, count=num, tweet_mode='extended')
+    kwargs = {'id': tid, 'count': num}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    rt_ary = t.statuses.retweets(**kwargs)
     if not rt_ary:
         printNicely(magenta('This tweet has no retweet.'))
         return
@@ -590,14 +609,18 @@ def conversation():
         printNicely(red('Sorry I can\'t understand.'))
         return
     tid = c['tweet_dict'][id]
-    tweet = t.statuses.show(id=tid, tweet_mode='extended')
+    kwargs = {'id': tid}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    tweet = t.statuses.show(**kwargs)
     limit = c['CONVERSATION_MAX']
     thread_ref = []
     thread_ref.append(tweet)
     prev_tid = tweet['in_reply_to_status_id']
     while prev_tid and limit:
         limit -= 1
-        tweet = t.statuses.show(id=prev_tid, tweet_mode='extended')
+        kwargs['id'] = prev_tid
+        tweet = t.statuses.show(**kwargs)
         prev_tid = tweet['in_reply_to_status_id']
         thread_ref.append(tweet)
 
@@ -664,7 +687,10 @@ def favorite():
     tid = c['tweet_dict'][id]
     t.favorites.create(_id=tid, include_entities=False)
     printNicely(green('Favorited.'))
-    draw(t.statuses.show(id=tid, tweet_mode='extended'))
+    kwargs = {'id': tid}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    draw(t.statuses.show(**kwargs))
     printNicely('')
 
 
@@ -681,7 +707,10 @@ def unfavorite():
     tid = c['tweet_dict'][id]
     t.favorites.destroy(_id=tid)
     printNicely(green('Okay it\'s unfavorited.'))
-    draw(t.statuses.show(id=tid, tweet_mode='extended'))
+    kwargs = {'id': tid}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    draw(t.statuses.show(**kwargs))
     printNicely('')
 
 
@@ -696,7 +725,10 @@ def share():
     except:
         printNicely(red('Tweet id is not valid.'))
         return
-    tweet = t.statuses.show(id=tid, tweet_mode='extended')
+    kwargs = {'id': tid}
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    tweet = t.statuses.show(**kwargs)
     url = 'https://twitter.com/' + \
         tweet['user']['screen_name'] + '/status/' + str(tid)
     import platform

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -355,7 +355,7 @@ def mentions():
     num = c['HOME_TWEET_NUM']
     if g['stuff'].isdigit():
         num = int(g['stuff'])
-    for tweet in reversed(t.statuses.mentions_timeline(count=num)):
+    for tweet in reversed(t.statuses.mentions_timeline(count=num, tweet_mode='extended')):
         draw(t=tweet)
     printNicely('')
 
@@ -535,7 +535,7 @@ def quote():
         printNicely(red('Sorry I can\'t understand.'))
         return
     tid = c['tweet_dict'][id]
-    tweet = t.statuses.show(id=tid)
+    tweet = t.statuses.show(id=tid, tweet_mode='extended')
     # Get formater
     formater = format_quote(tweet)
     if not formater:
@@ -569,7 +569,7 @@ def allretweet():
     except:
         num = c['RETWEETS_SHOW_NUM']
     # Get result and display
-    rt_ary = t.statuses.retweets(id=tid, count=num)
+    rt_ary = t.statuses.retweets(id=tid, count=num, tweet_mode='extended')
     if not rt_ary:
         printNicely(magenta('This tweet has no retweet.'))
         return
@@ -589,14 +589,14 @@ def conversation():
         printNicely(red('Sorry I can\'t understand.'))
         return
     tid = c['tweet_dict'][id]
-    tweet = t.statuses.show(id=tid)
+    tweet = t.statuses.show(id=tid, tweet_mode='extended')
     limit = c['CONVERSATION_MAX']
     thread_ref = []
     thread_ref.append(tweet)
     prev_tid = tweet['in_reply_to_status_id']
     while prev_tid and limit:
         limit -= 1
-        tweet = t.statuses.show(id=prev_tid)
+        tweet = t.statuses.show(id=prev_tid, tweet_mode='extended')
         prev_tid = tweet['in_reply_to_status_id']
         thread_ref.append(tweet)
 
@@ -663,7 +663,7 @@ def favorite():
     tid = c['tweet_dict'][id]
     t.favorites.create(_id=tid, include_entities=False)
     printNicely(green('Favorited.'))
-    draw(t.statuses.show(id=tid))
+    draw(t.statuses.show(id=tid, tweet_mode='extended'))
     printNicely('')
 
 
@@ -680,7 +680,7 @@ def unfavorite():
     tid = c['tweet_dict'][id]
     t.favorites.destroy(_id=tid)
     printNicely(green('Okay it\'s unfavorited.'))
-    draw(t.statuses.show(id=tid))
+    draw(t.statuses.show(id=tid, tweet_mode='extended'))
     printNicely('')
 
 
@@ -695,7 +695,7 @@ def share():
     except:
         printNicely(red('Tweet id is not valid.'))
         return
-    tweet = t.statuses.show(id=tid)
+    tweet = t.statuses.show(id=tid, tweet_mode='extended')
     url = 'https://twitter.com/' + \
         tweet['user']['screen_name'] + '/status/' + str(tid)
     import platform

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -330,7 +330,7 @@ def home():
     num = c['HOME_TWEET_NUM']
     if g['stuff'].isdigit():
         num = int(g['stuff'])
-    for tweet in reversed(t.statuses.home_timeline(count=num)):
+    for tweet in reversed(t.statuses.home_timeline(count=num, tweet_mode='extended')):
         draw(t=tweet)
     printNicely('')
 
@@ -399,7 +399,7 @@ def view():
         except:
             num = c['HOME_TWEET_NUM']
         for tweet in reversed(
-                t.statuses.user_timeline(count=num, screen_name=user[1:])):
+                t.statuses.user_timeline(count=num, screen_name=user[1:], tweet_mode='extended')):
             draw(t=tweet)
         printNicely('')
     else:
@@ -416,7 +416,7 @@ def view_my_tweets():
     except:
         num = c['HOME_TWEET_NUM']
     for tweet in reversed(
-            t.statuses.user_timeline(count=num, screen_name=g['original_name'])):
+            t.statuses.user_timeline(count=num, screen_name=g['original_name'], tweet_mode='extended')):
         draw(t=tweet)
     printNicely('')
 

--- a/rainbowstream/util.py
+++ b/rainbowstream/util.py
@@ -13,7 +13,7 @@ def detail_twitter_error(twitterException):
     try:
         for m in data.get('errors', dict()):
             printNicely(yellow(m.get('message')))
-    except: 
+    except:
         printNicely(yellow(data))
 
 
@@ -47,3 +47,12 @@ def format_prefix(listname='', keyword=''):
     formattedPrefix = formattedPrefix.replace('#me', '@' + c['original_name'])
 
     return formattedPrefix
+
+
+def add_tweetmode_parameter(kwargs):
+    """
+    Add support for extended mode to Twitter API calls unless explicitly stated in config
+    """
+    if not c.get('DISABLE_EXTENDED_TWEETS'):
+        kwargs['tweet_mode'] = 'extended'
+    return kwargs


### PR DESCRIPTION
AFAIK, these modifications allow correct display of 280 character tweets (including RTs) in the default stream and using the `home`, `view` and `me` commands.

It's all been quickly tested by hand and seems ok, but I wouldn't be surprised to have missed some functionalities on the way.