### PR TITLE
Allow specifying the location of oauth files

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,6 +113,16 @@ provided as follows:
 Both ``--proxy-port`` and ``--proxy-type`` can be omitted. In this case default
 proxy port ``8080`` and default proxy type ``SOCKS5`` are used.
 
+If you would like to specify an alternate location for storing the OAuth credential files for both twitter and pocket you can do so with the ``--twitter-auth`` and ``--pocket-auth`` settings. This is also useful if you wish to have multiple accounts for rainbowstream. Specify a location as follows:
+
+.. code:: bash
+
+    rainbowstream --twitter-auth /path/to/twitter_oauth
+    # or using the short form:
+    rainbowstream -ta /path/to/twitter_oauth
+
+If the oauth file doesn't exist at the location you specified then a new one will be created and you'll be required to autenticate with Twitter again.
+
 The interactive mode
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -89,6 +89,16 @@ def parse_arguments():
         '--proxy-type',
         default='SOCKS5',
         help='Proxy type (HTTP, SOCKS4, SOCKS5; Default: SOCKS5).')
+    parser.add_argument(
+        '-ta',
+        '--twitter-auth',
+        default=os.environ.get('HOME', os.environ.get('USERPROFILE', '')) + os.sep + '.rainbow_oauth',
+        help='Specify which OAuth profile to use for twitter. Default: ~/.rainbow_oauth.')
+    parser.add_argument(
+        '-pa',
+        '--pocket-auth',
+        default=os.environ.get('HOME', os.environ.get('USERPROFILE', '')) + os.sep + '.rainbow_pckt_oauth',
+        help='Specify which OAuth profile to use for pocket. Default: ~/.rainbow_pckt_oauth.')
     return parser.parse_args()
 
 
@@ -122,11 +132,7 @@ def authen():
     Authenticate with Twitter OAuth
     """
     # When using rainbow stream you must authorize.
-    twitter_credential = os.environ.get(
-        'HOME',
-        os.environ.get(
-            'USERPROFILE',
-            '')) + os.sep + '.rainbow_oauth'
+    twitter_credential = g['twitter_oauth_path']
     if not os.path.exists(twitter_credential):
         oauth_dance('Rainbow Stream',
                     CONSUMER_KEY,
@@ -144,12 +150,7 @@ def pckt_authen():
     """
     Authenticate with Pocket OAuth
     """
-    pocket_credential = os.environ.get(
-         'HOME',
-        os.environ.get(
-            'USERPROFILE',
-            '')) + os.sep + '.rainbow_pckt_oauth'
-
+    pocket_credential = g['pocket_oauth_path']
     if not os.path.exists(pocket_credential):
         request_token = Pocket.get_request_token(consumer_key=PCKT_CONSUMER_KEY)
         auth_url = Pocket.get_auth_url(code=request_token, redirect_uri="/")
@@ -238,6 +239,9 @@ def init(args):
     # Handle Ctrl C
     ctrl_c_handler = lambda signum, frame: quit()
     signal.signal(signal.SIGINT, ctrl_c_handler)
+    # Set OAuth file path (needs to happen before authen is called)
+    g['twitter_oauth_path'] = args.twitter_auth
+    g['pocket_oauth_path'] = args.pocket_auth
     # Upgrade notify
     upgrade_center()
     # Get name


### PR DESCRIPTION
This should address feature request #54 for multiple account support. It also maintains backwards compatibility with existing oauth file locations.