### PR TITLE
Fix search command bug when # of results < count.

### DIFF
--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -454,7 +454,7 @@ def search():
     # Return results
     if rel:
         printNicely('Newest tweets:')
-        for i in reversed(xrange(count)):
+        for i in reversed(xrange(min(len(rel), count))):
             draw(t=rel[i], keyword=query)
         printNicely('')
     else:


### PR DESCRIPTION
This PR fixes `search` command's minor bug (I use `s keyword` frequently).
When the size of `search` results is smaller than `count` parameter, raise `IndexError` and no tweets are displayed. Instead, `'OMG something is wrong with Twitter API right now.'` are displayed.
This error occurs frequently.
This is due to `for i in reversed(xrange(count)): rel[i]`, so this PR use `xrange(min(len(rel), count))`.
