### PR TITLE
Add #permalink to tweet format

### DIFF
--- a/rainbowstream/draw.py
+++ b/rainbowstream/draw.py
@@ -373,6 +373,9 @@ def draw(t, keyword=None, humanize=True, noti=False, fil=[], ig=[]):
         delimiter = color_func(c['TWEET']['client'])(
             client.join(word.split('#client')))
         formater = delimiter.join(formater.split(word))
+        # Change permalink word
+        permalink = 'https://twitter.com/' + screen_name.lstrip('@ ') + '/status/' + str(tid)
+        formater = permalink.join(formater.split('#permalink'))
     except:
         pass
 


### PR DESCRIPTION
I use rainbowstream as a way of monitoring tweets as they happen, but sometimes I want to be able to actually go to twitter when I see something pop up.

This makes `#permalink` generate a permalink for easy clicking.

Went this route because for some reason `#owner` and `#tid` were not available in this part of the formatter? This could also be modified to just include those, then I could put `https://twitter.com/#owner/status/#tid` into my FORMAT in the config.