### PR TITLE
Polling time now can be configured in the .rainbow_config.json file

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -331,6 +331,8 @@ If you would like to specify a different location for your custom config you can
 
 You also can view or set a new value of every config key with the ``config`` command (See **Interactive mode** section above).
 
+-  ``POLLING_TIME``: Time in seconds between each automatic poll. Most Twitter accounts have a limit of 15 requests each 15 minutes. If in doubt, set it to 90 or more.
+
 -  ``HEARTBEAT_TIMEOUT``: after this timeout (count by minutes), the stream will automatically hangup.
 
 -  ``IMAGE_ON_TERM``: display tweet's image directly on terminal.

--- a/rainbowstream/colorset/config
+++ b/rainbowstream/colorset/config
@@ -1,4 +1,6 @@
 {
+    //Time in seconds between each automatic poll. Most Twitter accounts have a limit of 15 requests each 15 minutes. If in doubt, set it to 90 or more. 
+    "POLLING_TIME" : 90,
     // Turn to 'true' in order to disable extended tweets display (legacy mode)
     "DISABLE_EXTENDED_TWEETS" : false,
     // After 120 minutes, the stream will automatically hangup

--- a/rainbowstream/rainbow.py
+++ b/rainbowstream/rainbow.py
@@ -2167,7 +2167,7 @@ def stream(domain, args, name='Rainbow Stream'):
     if args.track_keywords:
         query_args['track'] = args.track_keywords
 
-    polling_time = 90
+    polling_time = c['POLLING_TIME']
     while True:
         time.sleep(polling_time)
         poll()


### PR DESCRIPTION
There are Twitter Premium users who can fetch information more frequently than regular users. Other users would rather slow down polling in favour of manually refreshing the stream.