### PR TITLE
docs: fix simple typo, diplay -> display

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -339,7 +339,7 @@ You also can view or set a new value of every config key with the ``config`` com
 
 -  ``THEME``: current theme.
 
--  ``ASCII_ART``: diplay your twitter name by ascii art at stream begin or not.
+-  ``ASCII_ART``: display your twitter name by ascii art at stream begin or not.
 
 -  ``HIDE_PROMPT``: hide prompt after receiving a tweet or not.
 


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `display` rather than `diplay`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md