### PR TITLE
Update py3patch.py

### DIFF
--- a/rainbowstream/py3patch.py
+++ b/rainbowstream/py3patch.py
@@ -4,18 +4,20 @@ import sys
 if sys.version[0] == "2":
     from HTMLParser import HTMLParser
     from urllib2 import URLError
+    unescape = HTMLParser().unescape
 else:
     from html.parser import HTMLParser
     from urllib.error import URLError
+    # HTMLParser().unescape is deprecated since Python 3.4 and is unsafe.
+    # you should use html.unescape instead, like you've said
+    from html import unescape
 
 # unescape = HTMLParser().unescape
 # According to https://github.com/python/cpython/blob/master/Lib/html/parser.py#L547 ,
 # in python 3.5 maybe I should use
 # from html import unescape
 # ~~but it is a far-future story:)~~ no longer. 
-# HTMLParser().unescape is deprecated since Python 3.4 and is unsafe.
-# you should use html.unescape instead, like you've said
-from html import unescape
+
 
 
 # Function compatibility

--- a/rainbowstream/py3patch.py
+++ b/rainbowstream/py3patch.py
@@ -8,11 +8,14 @@ else:
     from html.parser import HTMLParser
     from urllib.error import URLError
 
-unescape = HTMLParser().unescape
+# unescape = HTMLParser().unescape
 # According to https://github.com/python/cpython/blob/master/Lib/html/parser.py#L547 ,
 # in python 3.5 maybe I should use
 # from html import unescape
-# but it is a far-future story:)
+# ~~but it is a far-future story:)~~ no longer. 
+# HTMLParser().unescape is deprecated since Python 3.4 and is unsafe.
+# you should use html.unescape instead, like you've said
+from html import unescape
 
 
 # Function compatibility


### PR DESCRIPTION
Remove deprecated `HTMLParser.HTMLParser.unescape` and replace it with `html.unescape` making it safer and working on Python 3.9.