### PR TITLE
Theme names more obvious

### DIFF
--- a/theme.md
+++ b/theme.md
@@ -1,11 +1,11 @@
 ## Available themes
-#### Monokai
+#### Monokai (`monokai`)
 ![Monokai](./screenshot/themes/Monokai.png)
-#### Solarized
+#### Solarized (`solarized`)
 ![Solarized](./screenshot/themes/Solarized.png)
-#### Tomorrow Night
+#### Tomorrow Night (`tomorrow_night`)
 ![Solarized](./screenshot/themes/TomorrowNight.png)
-#### Larapaste
+#### Larapaste (`larapaste`)
 ![Solarized](./screenshot/themes/larapaste.png)
 
 ## Customization


### PR DESCRIPTION
Make the theme names more clear/obvious.

Especially with the "tomorrow night" theme. I didn't knew if the words are written to each other. Or with a space or underscore (last option is correct btw).

Regards, Melroy